### PR TITLE
WIP:Pin VSPK version to 5.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache py3-paramiko openssh-client sshpass py3-lxml build-base p
         textfsm \
         netmiko \
         coloredlogs \
-        vspk && \
+        'vspk>=5,<6' && \
     rm -r /root/.cache && \
     ln -s /usr/bin/python3 /usr/bin/python
 


### PR DESCRIPTION
For the rel_5 container, we should ship a vspk 5.x.x