### PR TITLE
Pin VSPK version to 6.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache py3-paramiko openssh-client sshpass py3-lxml build-base p
         textfsm \
         netmiko \
         coloredlogs \
-        vspk && \
+        'vspk>=6,<7' && \
     rm -r /root/.cache && \
     ln -s /usr/bin/python3 /usr/bin/python
 


### PR DESCRIPTION
For rel_6 container we should ship vspk 6.x.x